### PR TITLE
Master contributed

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Application Options:
 -w, --lag-warning= Slave lag warning threshold (default: 300)
 -c, --lag-critical= Slave lag critical threshold (default: 600)
 --http-auth-name Name for the http auth 
--http-auth-password Password for http auth 
+--http-auth-password Password for http auth 
 Help Options:
 -h, --help Show this help message
 ```

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Application Options:
 -S, --ssl Use SSL
 -I, --insecure Do not check SSL cert
 -U, --uri= URI (default: api/health)
+-u, --http-auth-name Name for the http auth 
+-p, --http-auth-password Password for http auth  
 Help Options:
 -h, --help Show this help message
---http-auth-name Name for the http auth
---http-auth-password Password for http auth  
 ```
 
 #### Success
@@ -59,6 +59,8 @@ Application Options:
 -S, --ssl Use SSL
 -I, --insecure Do not check SSL cert
 -U, --uri= URI (default: api/clusters-info)
+-u, --http-auth-name Name for the http auth 
+-p, --http-auth-password Password for http auth 
 Help Options:
 -h, --help Show this help message
 ```
@@ -90,6 +92,8 @@ Application Options:
 -t, --timeout= Timeout for SecondsSinceLastSeen (default: 300)
 -w, --lag-warning= Slave lag warning threshold (default: 300)
 -c, --lag-critical= Slave lag critical threshold (default: 600)
+-u, --http-auth-name Name for the http auth 
+-p, --http-auth-password Password for http auth 
 Help Options:
 -h, --help Show this help message
 ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Application Options:
 -U, --uri= URI (default: api/health)
 Help Options:
 -h, --help Show this help message
+--http-auth-name Name for the http auth
+--http-auth-pass Password for http auth  
 ```
 
 #### Success

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Application Options:
 -S, --ssl Use SSL
 -I, --insecure Do not check SSL cert
 -U, --uri= URI (default: api/health)
---http-auth-name Name for the http auth 
+--http-auth-name Name for http auth 
 --http-auth-password Password for http auth  
 Help Options:
 -h, --help Show this help message
@@ -59,7 +59,7 @@ Application Options:
 -S, --ssl Use SSL
 -I, --insecure Do not check SSL cert
 -U, --uri= URI (default: api/clusters-info)
---http-auth-name Name for the http auth 
+--http-auth-name Name for http auth 
 --http-auth-password Password for http auth 
 Help Options:
 -h, --help Show this help message
@@ -92,7 +92,7 @@ Application Options:
 -t, --timeout= Timeout for SecondsSinceLastSeen (default: 300)
 -w, --lag-warning= Slave lag warning threshold (default: 300)
 -c, --lag-critical= Slave lag critical threshold (default: 600)
---http-auth-name Name for the http auth 
+--http-auth-name Name for http auth 
 --http-auth-password Password for http auth 
 Help Options:
 -h, --help Show this help message

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Application Options:
 Help Options:
 -h, --help Show this help message
 --http-auth-name Name for the http auth
---http-auth-pass Password for http auth  
+--http-auth-password Password for http auth  
 ```
 
 #### Success

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Application Options:
 -S, --ssl Use SSL
 -I, --insecure Do not check SSL cert
 -U, --uri= URI (default: api/health)
--u, --http-auth-name Name for the http auth 
--p, --http-auth-password Password for http auth  
+--http-auth-name Name for the http auth 
+--http-auth-password Password for http auth  
 Help Options:
 -h, --help Show this help message
 ```
@@ -59,8 +59,8 @@ Application Options:
 -S, --ssl Use SSL
 -I, --insecure Do not check SSL cert
 -U, --uri= URI (default: api/clusters-info)
--u, --http-auth-name Name for the http auth 
--p, --http-auth-password Password for http auth 
+--http-auth-name Name for the http auth 
+--http-auth-password Password for http auth 
 Help Options:
 -h, --help Show this help message
 ```
@@ -92,8 +92,8 @@ Application Options:
 -t, --timeout= Timeout for SecondsSinceLastSeen (default: 300)
 -w, --lag-warning= Slave lag warning threshold (default: 300)
 -c, --lag-critical= Slave lag critical threshold (default: 600)
--u, --http-auth-name Name for the http auth 
--p, --http-auth-password Password for http auth 
+--http-auth-name Name for the http auth 
+-http-auth-password Password for http auth 
 Help Options:
 -h, --help Show this help message
 ```

--- a/check_orchestrator.go
+++ b/check_orchestrator.go
@@ -28,8 +28,8 @@ type orchestratorOpts struct {
 	Port   string `short:"p" long:"port" default:"3000" description:"Port"`
 	SSL    bool   `short:"S" long:"ssl" description:"Use SSL"`
 	NoCert bool   `short:"I" long:"insecure" description:"Do not check SSL cert"`
-	HttpAuthName string   `long:"http-auth-name" description:"Http authorization name"`
-	HttpAuthPass string   `long:"http-auth-password" description:"Http authorization password"`
+	HttpAuthName string   `short:"u" long:"http-auth-name" description:"Http authorization name"`
+	HttpAuthPass string   `short:"p" long:"http-auth-password" description:"Http authorization password"`
 }
 
 func separateSub(argv []string) (string, []string) {

--- a/check_orchestrator.go
+++ b/check_orchestrator.go
@@ -28,6 +28,8 @@ type orchestratorOpts struct {
 	Port   string `short:"p" long:"port" default:"3000" description:"Port"`
 	SSL    bool   `short:"S" long:"ssl" description:"Use SSL"`
 	NoCert bool   `short:"I" long:"insecure" description:"Do not check SSL cert"`
+	HttpAuthName string   `long:"http-auth-name" description:"Http authorization name"`
+	HttpAuthPass string   `long:"http-auth-password" description:"Http authorization password"`
 }
 
 func separateSub(argv []string) (string, []string) {

--- a/check_orchestrator.go
+++ b/check_orchestrator.go
@@ -28,8 +28,8 @@ type orchestratorOpts struct {
 	Port   string `short:"p" long:"port" default:"3000" description:"Port"`
 	SSL    bool   `short:"S" long:"ssl" description:"Use SSL"`
 	NoCert bool   `short:"I" long:"insecure" description:"Do not check SSL cert"`
-	HttpAuthName string   `short:"u" long:"http-auth-name" description:"Http authorization name"`
-	HttpAuthPass string   `short:"p" long:"http-auth-password" description:"Http authorization password"`
+	HttpAuthName string   `long:"http-auth-name" description:"Http authorization name"`
+	HttpAuthPass string   `long:"http-auth-password" description:"Http authorization password"`
 }
 
 func separateSub(argv []string) (string, []string) {

--- a/clusterHealth.go
+++ b/clusterHealth.go
@@ -64,7 +64,14 @@ func checkClusterHealth(args []string) *checkers.Checker {
 	clusterAlias := opts.ClusterAlias
 	uri := fmt.Sprintf("%s://%s:%s/api/cluster/alias/%s", sslPrefix(opts.SSL), opts.Host, opts.Port, clusterAlias)
 	client := &http.Client{Transport: getHttpTransport(opts.NoCert)}
-	resp, err := client.Get(uri)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return checkers.NewChecker(checkers.UNKNOWN, fmt.Sprintf("Could not connect to Orchestrator API on %s", uri))
+	}
+	if opts.HttpAuthName != "" && opts.HttpAuthPass != ""  {
+		req.SetBasicAuth(opts.HttpAuthName, opts.HttpAuthPass)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return checkers.NewChecker(checkers.UNKNOWN, fmt.Sprintf("Could not connect to Orchestrator API on %s", uri))
 	}

--- a/clusterInfo.go
+++ b/clusterInfo.go
@@ -36,10 +36,16 @@ func checkClusterInfo(args []string) *checkers.Checker {
 	if err != nil {
 		os.Exit(1)
 	}
-
 	uri := fmt.Sprintf("%s://%s:%s/%s", sslPrefix(opts.SSL), opts.Host, opts.Port, opts.URI)
 	client := &http.Client{Transport: getHttpTransport(opts.NoCert)}
-	resp, err := client.Get(uri)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return checkers.NewChecker(checkers.UNKNOWN, fmt.Sprintf("Could not connect to Orchestrator API on %s", uri))
+	}
+	if opts.HttpAuthName != "" && opts.HttpAuthPass != ""  {
+		req.SetBasicAuth(opts.HttpAuthName, opts.HttpAuthPass)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return checkers.NewChecker(checkers.UNKNOWN, fmt.Sprintf("Could not connect to Orchestrator API on %s", uri))
 	}

--- a/status.go
+++ b/status.go
@@ -28,7 +28,16 @@ func checkStatus(args []string) *checkers.Checker {
 
 	uri := fmt.Sprintf("%s://%s:%s/%s", sslPrefix(opts.SSL), opts.Host, opts.Port, opts.URI)
 	client := &http.Client{Transport: getHttpTransport(opts.NoCert)}
-	resp, err := client.Get(uri)
+
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return checkers.NewChecker(checkers.UNKNOWN, fmt.Sprintf("Could not connect to Orchestrator API on %s", uri))
+	}
+	if opts.HttpAuthName != "" && opts.HttpAuthPass != ""  {
+		req.SetBasicAuth(opts.HttpAuthName, opts.HttpAuthPass)
+	}
+	resp, err := client.Do(req)
+
 	if err != nil {
 		return checkers.NewChecker(checkers.UNKNOWN, fmt.Sprintf("Could not connect to Orchestrator API on %s", uri))
 	}


### PR DESCRIPTION
**What?**

Additional parameters were added to go-check-orchestrator `--http-auth-name` along with --`http-auth-password`

**Why?**
In order to be able to verify status for an orchestrator that protected by Basic Auth, two additional params were added to commands `--http-auth-name` along with --`http-auth-password`, those values will be passed to status requests  